### PR TITLE
Change the Group CSV file

### DIFF
--- a/latex/groups.csv
+++ b/latex/groups.csv
@@ -1,11 +1,6 @@
-Group,Team
-Group A,My Team
-Group A,Team 1
-Group A,Team 2
-Group A,Team 3
-Group A,Team 4
-Group B,Team 5
-Group B,Team 6
-Group B,Team 7
-Group B,Team 8
-Group B,Team 9
+Group A,Group B
+My Team,Team 5
+Team 1,Team 6
+Team 2,Team 7
+Team 3,Team 8
+Team 4,Team 9

--- a/latex/groups.tex
+++ b/latex/groups.tex
@@ -19,16 +19,11 @@
 
 \usepackage{float}
 
-\usepackage{ifthen}
-
-\usepackage{tikz}
-
 \usepackage{pdflscape}
 
 \usepackage{tournamentstyle}
 
-\usepackage{datatool}% load data from csv files
-\usepackage{xstring} % for string operations (optional but convenient)
+\usepackage{pgfplotstable}
 
 \begin{document}
     \pagenumbering{gobble}
@@ -41,50 +36,14 @@
         \vspace{2em}
         \renewcommand{\arraystretch}{1.25}
         
-        % Load the group data from csv
-        \DTLloaddb{groupdata}{groups.csv}
-
-        % Extract unique groups into a temporary macro for iteration
-        \let\groupNames\empty
-
-        % Iterate over all rows to collect unique groups
-        \DTLforeach{groupdata}{\group=Group}{%
-        	% Check if the group has already been found
-        	\IfSubStr{\groupNames}{\group}{%
-        	}{%
-        		% Not found, add to list
-        		\ifx\groupNames\empty%
-        			% First entry, no leading comma
-        			\edef\groupNames{\group}%
-        		\else
-        			% Not first, so repeat the already found group names and insert a comma
-        			\edef\groupNames{\groupNames,\group}%
-        		\fi
-        	}%
-        }
-
-        % Now iterate over the unique groups and print tabulars
         \LARGE
-        \setlength{\tabcolsep}{1em}
-        \foreach \thisgroup in \groupNames {%
-        	% Find the teams from this group and store them separated by \\
-        	\let\teamNames\empty%
-        	\DTLforeach{groupdata}{\group=Group,\team=Team}{%
-        		\ifthenelse{\equal{\group}{\thisgroup}}{
-       				\edef\teamNames{\teamNames\team\\}%
-        		}{}%
-        	}
-        	% Print the teams inside a tabular
-	        \begin{tabular}{|l|}
-		        \hline
-		        \textbf{\thisgroup}\\
-		        \hline
-		        \teamNames
-		        \hline
-		        \multicolumn{1}{c}{}\\
-	        \end{tabular}%
-	        \hspace{2em}
-        }
-        \hspace{-2.5em}
+        \setlength{\tabcolsep}{1.5em} % Space between columns
+	    \pgfplotstableset{
+	       	col sep=comma, % Separator used in the CSV file
+	       	string type, % Treat all columns as strings
+	       	header=true, % Use the first row as headers
+	       	assign column name/.style={/pgfplots/table/column name={\textbf{#1}}}, % Column names in bold
+	    }
+		\pgfplotstabletypeset{groups.csv}
     \end{landscape}
 \end{document}

--- a/model/tournament_plan.py
+++ b/model/tournament_plan.py
@@ -108,10 +108,9 @@ class TournamentPlan:
 
     def write_csv_groups(self, filename: str = "latex/groups.csv") -> None:
         with open(filename, 'w', encoding="utf-8") as file:
-            file.write("Group,Team\n")
-            for group in self.groups:
-                for team in group.teams:
-                    file.write(f"{group.name},{team.name}\n")
-    
+            file.write(','.join(group.name for group in self.groups) + "\n")
+            for t in range(max(group.size for group in self.groups)):
+                file.write(','.join(group.teams[t].name if t < group.size else '' for group in self.groups ) + "\n")
+
     def __str__(self) -> str:
         return self.get_teams_schedule()


### PR DESCRIPTION
The csv file for the groups overview should have a column for each group with the group name in the header row and the respective team names below.